### PR TITLE
Styles should not assume the rvt-sticker will be defined

### DIFF
--- a/src/rivet-sticker-element.css
+++ b/src/rivet-sticker-element.css
@@ -83,7 +83,7 @@ rvt-sticker[size="xl"] {
 	--size: var(--size-xl);
 }
 
-rvt-sticker:not(:defined)::before,
+rvt-sticker:empty::before,
 rvt-sticker > svg {
 	background-color: var(--bg, var(--color-black-100));
 	border-radius: 100%;


### PR DESCRIPTION
The CSS selector `rvt-sticker:not(:defined)::before` assumes that the Rivet Sticker Element will be defined. However, there may be a case in which the user wants to use a sticker but have it statically rendered by manually copying the sticker SVG code (due to server-side rendering or restrictive front-end environments).

```html
<rvt-sticker>
  <svg…>
</rvt-sticker>
```

Instead, by updating that selector to `rvt-sticker:empty::before`, it means that the initial loading style (empty circle background in a pseudo element) will only be applied if the element is empty (such as waiting for the custom element to be defined) — not when there is something there (such as when SVG is manually included or when the custom element is attached to the DOM).